### PR TITLE
Version 0.4 beta

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,7 +34,12 @@ module.exports = {
             "error",
             "never"
         ],
-        "no-console": 0,
+        "no-console": [
+			"error",
+			{
+				"allow": [ "warn", "error", "info" ]
+			}
+		],
 		"no-unused-vars": [
 			2,
 			{ "args": "none" }

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+bower_components
 npm-debug.log
 yarn.lock
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ my-component.html
 	<style>
 		/* styles */
 	</style>
-	T<input type="text" value="::this.userName" oninput="::this.userName = this.value">
-	[[::this.greeting]]
+	<input type="text" value="::this.userName" oninput="::this.userName = this.value">
+	((this.greeting))
 </template>
 
 <script type="text/javascript">

--- a/README.md
+++ b/README.md
@@ -36,24 +36,18 @@ my-component.html
 		/* styles */
 	</style>
 	<input type="text" ::value="this.userName" oninput="this.userName = value">
-	((this.greeting))
+	((this.userName ? 'Hello, ' + this.userName : ''))
 </template>
 
 <script type="text/javascript">
 	class MyComponent extends Custom.Element {
 
 		static get is() { return 'my-component' }
-		static get observedProperties () { return ['userName', 'greeting'] }
+		static get observedProperties () { return ['userName'] }
 
 		constructor() {
 			super()
 			this.userName = 'Arthur'
-		}
-
-		set userName (value) {
-			this.greeting = value
-				? "Hello " + value
-				: ''
 		}
 
 	}

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ my-component.html
 	<style>
 		/* styles */
 	</style>
-	<input type="text" value="::this.userName" oninput="::this.userName = this.value">
+	<input type="text" ::value="this.userName" oninput="this.userName = value">
 	((this.greeting))
 </template>
 

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
 	"version": "0.4.0b",
   "description": "Lightweight library to create your own custom HTML elements, using web standard Web Component API",
   "main": [
-		"carbonium.html"
+		"dist/carbonium.html"
 	],
   "authors": [
     "Arthur Lavrischev <ar2r13lawrence@gmail.com>"
@@ -11,10 +11,8 @@
   "license": "MIT",
   "homepage": "https://github.com/ar2r13/Carbonium",
   "ignore": [
-    "bower_components",
 		"src",
 		"**/.*",
-		"package.json",
-		"bower.json"
+		"package.json"
   ]
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Carbonium",
-	"version": "0.3.3b",
+	"version": "0.4.0b",
   "description": "Lightweight library to create your own custom HTML elements, using web standard Web Component API",
   "main": [
 		"carbonium.html"
@@ -11,10 +11,10 @@
   "license": "MIT",
   "homepage": "https://github.com/ar2r13/Carbonium",
   "ignore": [
-    "node_modules",
     "bower_components",
 		"src",
 		"**/.*",
-		"package.json"
+		"package.json",
+		"bower.json"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "Carbonium",
 	"description": "Lightweight library to create your own custom HTML elements, using web standard Web Component API",
-	"version": "0.3.3b",
+	"version": "0.4.0b",
 	"license": "MIT",
 	"devDependencies": {
 		"babel-eslint": "^7.2.1",

--- a/src/carbonium.html
+++ b/src/carbonium.html
@@ -3,7 +3,7 @@
 <script type="text/javascript">
 	'use strict'
 
-	function Custom(superClass) {
+	function Custom(superClass = HTMLElement) {
 		/* eslint-disable no-undef */
 		const mixins = [
 			Templating,

--- a/src/data-flow/data-binding.js
+++ b/src/data-flow/data-binding.js
@@ -21,12 +21,8 @@ function DataBinding(SuperClass : HTMLElement) : Object { // eslint-disable-line
 
 			let node
 			while ((node = nodeIterator.nextNode())) {
-				if(node.nodeType === 1 && node.attributes.length) { // element
-					elements.push(node)
-				}
-				if(node.nodeType === 3 && node.data) { // text node
-					textNodes.push(node)
-				}
+				if(node.nodeType === 1 && node.attributes.length) elements.push(node) //element
+				if(node.nodeType === 3 && node.data) textNodes.push(node) // text node
 			}
 
 			if(elements.length) {
@@ -103,7 +99,7 @@ function DataBinding(SuperClass : HTMLElement) : Object { // eslint-disable-line
 
 		const newValue : any = (node : Text) : any => {
 			value = value == null
-				? /*::`*/this::evluatedExp(node, ref)/*::`*/
+				? /*::`*/this::evaluatedExp(node, ref)/*::`*/
 				: value
 			return value
 		}
@@ -139,12 +135,12 @@ function DataBinding(SuperClass : HTMLElement) : Object { // eslint-disable-line
 			if(!attr.value.length || !availablePrefixes.includes(prefix)) continue
 
 			const binding : Function = () => {
-				const value : any = /*::`*/this::evluatedExp(elem, attr.value)/*::`*/
+				const value : any = /*::`*/this::evaluatedExp(elem, attr.value)/*::`*/
 				switch (prefix) {
 					case 'on':
 						elem[prop] = (() => typeof value === 'function'
 								? value.call(this, event, elem)
-								: /*::`*/this::evluatedExp(elem, attr.value)/*::`*/
+								: /*::`*/this::evaluatedExp(elem, attr.value)/*::`*/
 						).bind(this)
 						break
 					case '::':
@@ -171,18 +167,8 @@ function DataBinding(SuperClass : HTMLElement) : Object { // eslint-disable-line
 		}
 	}
 
-	function evluatedExp (context : Element, exp : string) : any {
-		return new Function('$', `
-			let v
-			with($) {
-				try {
-					v = ${exp}
-				} catch(e) {
-					console.error(e)
-					return '[' + e.name + ']: ' + e.message
-				}
-				return v
-			}`
-		).call(this, context)
+	function evaluatedExp (context : Element, exp : string) : any {
+		return new Function('$', `let v;with($){try{v=${exp}}catch(e){console.error(e);return '['+e.name+']: '+e.message}return v}`)
+			.call(this, context)
 	}
 }

--- a/src/data-flow/data-binding.js
+++ b/src/data-flow/data-binding.js
@@ -1,12 +1,13 @@
 // @flow
 'use strict'
 
-function dataBinding(SuperClass : HTMLElement) : Object { // eslint-disable-line no-unused-vars
+function DataBinding(SuperClass : HTMLElement) : Object { // eslint-disable-line no-unused-vars
 
 	const bindings : WeakMap<Element, Array<Function>> = new WeakMap()
 	const stamps : WeakMap<Element, Object> = new WeakMap()
 
 	const stampErrorMessage : string = '[WebComponent] Something went wrong. No stamps storage found.'
+	const rootPropRegX : RegExp = /this[\.\[]+(\w+)/g
 
 	// flow-ignore-line
 	return class extends SuperClass {
@@ -84,8 +85,7 @@ function dataBinding(SuperClass : HTMLElement) : Object { // eslint-disable-line
 			const observedProperties : Array<string> = this.constructor.observedProperties
 			if(Array.isArray(observedProperties)) {
 				let result
-				const RegX : RegExp = /this[\.\[]+(\w+)/g
-				while((result = RegX.exec(ref))) {
+				while((result = rootPropRegX.exec(ref))) {
 					if(observedProperties.includes(result[1])) {
 						this.observables.subscribe(result[1], value => /*::`*/this::setStamp(ref)/*::`*/)
 					}
@@ -160,8 +160,7 @@ function dataBinding(SuperClass : HTMLElement) : Object { // eslint-disable-line
 
 			if (Array.isArray(observedProperties)) {
 				let result
-				const RegX : RegExp = /\$[\.\[]+(\w+)/g
-				while((result = RegX.exec(attr.value))) {
+				while((result = rootPropRegX.exec(attr.value))) {
 					if(observedProperties.includes(result[1])) {
 						this.observables.subscribe(result[1], binding)
 					}

--- a/src/data-flow/data-binding.js
+++ b/src/data-flow/data-binding.js
@@ -173,6 +173,17 @@ function dataBinding(SuperClass : HTMLElement) : Object { // eslint-disable-line
 	}
 
 	function evluatedExp (context : Element, exp : string) : any {
-		return new Function('$', `with($) { return ${exp} }`).call(this, context)
+		return new Function('$', `
+			let v
+			with($) {
+				try {
+					v = ${exp}
+				} catch(e) {
+					console.error(e)
+					return '[' + e.name + ']: ' + e.message
+				}
+				return v
+			}`
+		).call(this, context)
 	}
 }

--- a/src/data-flow/data-binding.js
+++ b/src/data-flow/data-binding.js
@@ -52,7 +52,7 @@ function dataBinding(SuperClass : HTMLElement) : Object { // eslint-disable-line
 	function detectStamp(node : Text) {
 		if(node.nodeType !== 3 || !node.data.trim()) return
 
-		const stampSelector : RegExp = /(\(\(\s*\w+.*\)\))/gim
+		const stampSelector : RegExp = /(\(\(.+?\)\))/gim
 		const chunks : Array<string> = node.data.split(stampSelector)
 
 		if(chunks.length <= 1) return

--- a/src/data-flow/data-flow.html
+++ b/src/data-flow/data-flow.html
@@ -4,6 +4,6 @@
 	'use strict'
 	/* eslint-disable no-unused-vars, no-undef */
 	function DataFlow (SuperClass) {
-		return class extends dataBinding(observedProperties(SuperClass)) {}
+		return class extends DataBinding(ObservedProperties(SuperClass)) {}
 	}
 </script>

--- a/src/data-flow/observed-properties.js
+++ b/src/data-flow/observed-properties.js
@@ -1,7 +1,7 @@
 // @flow
 'use strict'
 
-function observedProperties(SuperClass : HTMLElement) : Object { // eslint-disable-line no-unused-vars
+function ObservedProperties(SuperClass : HTMLElement) : HTMLElement { // eslint-disable-line no-unused-vars
 
 	const privates : WeakMap<Element, Object> = new WeakMap()
 
@@ -36,7 +36,7 @@ function observedProperties(SuperClass : HTMLElement) : Object { // eslint-disab
 		}
 	}
 
-	function observedPropertiesDecorator(target : Object) : HTMLElement { // eslint-disable-line no-unused-vars
+	function observedPropertiesDecorator(target : Object) : HTMLElement {
 		const observedProperties : Array<string> = target.observedProperties
 		if (!(observedProperties instanceof Array)) return target
 

--- a/src/data-flow/observed-properties.js
+++ b/src/data-flow/observed-properties.js
@@ -28,7 +28,10 @@ function ObservedProperties(SuperClass : HTMLElement) : HTMLElement { // eslint-
 			const observedProperties : Array<string> = this.constructor.observedProperties
 			if (observedProperties instanceof Array) {
 				privates.set(this, {})
-				this.observables = new Observable()
+				Object.defineProperty(this, 'observables', {
+					enumerable: false,
+					value: new Observable()
+				})
 			}
 		}
 		static get element() : typeof SuperClass {

--- a/src/templating/templating.js
+++ b/src/templating/templating.js
@@ -1,7 +1,7 @@
 // @flow
 'use strict'
 
-function Templating (SuperClass : HTMLElement) : Object { // eslint-disable-line no-unused-vars
+function Templating (SuperClass : ?HTMLElement) : HTMLElement { // eslint-disable-line no-unused-vars
 	const ownerDocument : typeof document = document.currentScript
 			? document.currentScript.ownerDocument
 			// flow-ignore-line webcomponents-polyfill
@@ -10,8 +10,7 @@ function Templating (SuperClass : HTMLElement) : Object { // eslint-disable-line
 	return class extends SuperClass {
 
 		static get template () : DocumentFragment {
-			const template : ?HTMLTemplateElement =
-				ownerDocument.querySelector('#' + this.is) || ownerDocument.querySelector('template')
+			const template : ?HTMLTemplateElement = ownerDocument.querySelector('#' + this.is) || ownerDocument.querySelector('template')
 			if(!template) throw new Error('Template not found')
 			return template.content.cloneNode(true)
 		}


### PR DESCRIPTION
# 0.4 beta
## New text-stamps syntax
###### *Old (v0.3.3):*
```html
<template>
  [[::this.greeting]]
</template>

<script>
class MyComponent extends Custom.element {
  static get observedProperties() {
    return ['greeting', 'userName']
  }
  // ...
  set userName(value) {
    this.greeting = value.trim() 
      ? 'Hello, ' + value
      : ''
  }
}
// ...
</script>
```
###### *New (v0.4):*
```html
<template>
  ((this.userName ? 'Hello, ' + this.userName : ''))
</template>
```
*```(...)```*
* You can run expression code here
* Became faster
* Handling all errors without blocking thread

## Changes in attribute binding API
###### *Old (v0.3.3):*
```html
<input type="text" value="::this.userName" oninput="::this.userName = this.value">
```
###### *New (v0.4):*
```html
<input type="text" ::value="this.userName" oninput="this.userName = value">
```
#### Computable attributes
In ```v0.3``` all attributes which contains '::this', automaticaly runs value like expressions.
In ```v0.4``` to make the attribute computable, need add ```::``` prefix to attribute name.